### PR TITLE
add interfaces method to server model

### DIFF
--- a/lib/fog/compute/gridscale/models/server.rb
+++ b/lib/fog/compute/gridscale/models/server.rb
@@ -77,6 +77,11 @@ module Fog
           end
         end
 
+        def interfaces
+          requires :object_uuid
+          service.server_relation_networks.all(object_uuid)
+        end
+
         def ipv6_address
           if (net = relations['public_ips'].find {|n|n['family']==6})
             net['ip']


### PR DESCRIPTION
foreman uses this during creation of servers
as described here:

https://github.com/gridscale/foreman-gridscale/pull/2