### PR TITLE
fix empty template_uuid string

### DIFF
--- a/lib/fog/compute/gridscale/requests/server_create.rb
+++ b/lib/fog/compute/gridscale/requests/server_create.rb
@@ -48,6 +48,9 @@ module Fog
           if sshkey_uuid == ""
             sshkey_uuid = nil
           end
+          if template_uuid == ""
+            template_uuid = nil
+          end
           if storage != nil && storage > 0
             if template_uuid !=nil
               storages << {"create"=>{"name"=>"#{name} Storage", "capacity"=>storage, "location_uuid"=>location_uuid,"storage_type"=>"storage","template"=>{"template_uuid"=> template_uuid }} , "relation"=>{"bootdevice"=>true}}


### PR DESCRIPTION
template_uuid is tested using !=nil while it is set by default to
an empty string. this led to the empty string being used
as value in the json send to the server.

this adds a test (like for sshkey_uuid) if template_uuid is the
empty string and sets it to nil if so, preventing it to be
considered in the json body.